### PR TITLE
add support to DownloadManager and ExternalStorage

### DIFF
--- a/android/src/main/java/com/rngrp/GRP.java
+++ b/android/src/main/java/com/rngrp/GRP.java
@@ -1,7 +1,10 @@
 package com.rngrp;
 
+import android.content.ContentUris;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Environment;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.database.Cursor;
 
@@ -32,22 +35,76 @@ public class GRP extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getRealPathFromURI(String uri, Callback callback) {
+  public void getRealPathFromURI(String uriString, Callback callback) {
+    Uri uri = Uri.parse(uriString);
     try {
       Context context = getReactApplicationContext();
+
+      if (isMediaDocument(uri)){
       String [] proj = {MediaStore.Images.Media.DATA};
-      Cursor cursor = context.getContentResolver().query(Uri.parse(uri), proj,  null, null, null);
+      Cursor cursor = context.getContentResolver().query(uri, proj,  null, null, null);
       int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
       cursor.moveToFirst();
-      String path = cursor.getString(column_index); 
+      String path = cursor.getString(column_index);
       cursor.close();
-  
+
       callback.invoke(null, path);
+      }
+      else if (isDownloadsDocument(uri)) {
+
+        final String id = DocumentsContract.getDocumentId(uri);
+        final Uri contentUri = ContentUris.withAppendedId(
+                Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+        callback.invoke(null, getDataColumn(context, contentUri, null, null)); ;
+      }
+      else if (isExternalStorageDocument(uri)) {
+        final String docId = DocumentsContract.getDocumentId(uri);
+        final String[] split = docId.split(":");
+        final String type = split[0];
+
+        if ("primary".equalsIgnoreCase(type)) {
+          callback.invoke(null, Environment.getExternalStorageDirectory() + "/" + split[1]);
+        }
+        // TODO handle non-primary volumes
+      }
     } catch (Exception ex) {
       ex.printStackTrace();
       callback.invoke(makeErrorPayload(ex));
     }
+
   }
 
-}
+  public static boolean isMediaDocument(Uri uri) {
+    return "com.android.providers.media.documents".equals(uri.getAuthority());
+  }
 
+  public static boolean isDownloadsDocument(Uri uri) {
+    return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+  }
+  public static boolean isExternalStorageDocument(Uri uri) {
+    return "com.android.externalstorage.documents".equals(uri.getAuthority());
+  }
+  public static String getDataColumn(Context context, Uri uri, String selection,
+                                     String[] selectionArgs) {
+
+    Cursor cursor = null;
+    final String column = "_data";
+    final String[] projection = {
+            column
+    };
+
+    try {
+      cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+              null);
+      if (cursor != null && cursor.moveToFirst()) {
+        final int column_index = cursor.getColumnIndexOrThrow(column);
+        return cursor.getString(column_index);
+      }
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
On the master, it's possible only to get the path from the MediaStorage specifically Images. 
I added the option of converting from DownloadManager and ExternalStorage.

Source: https://stackoverflow.com/questions/20067508/get-real-path-from-uri-android-kitkat-new-storage-access-framework/20559175#20559175