### PR TITLE
Update GRP.common.js to avoid crashes on iOS

### DIFF
--- a/GRP.common.js
+++ b/GRP.common.js
@@ -11,7 +11,7 @@ var GRP = require('react-native').NativeModules.GRP;
 var NativeAppEventEmitter = require('react-native').NativeAppEventEmitter;
 var Promise = require('bluebird');
 
-var _getRealPathFromURI = Promise.promisify(GRP.getRealPathFromURI);
+var _getRealPathFromURI = Promise.promisify(GRP ? GRP.getRealPathFromURI : (fileUri) => { return fileUri; });
 
 var convertError = (err) => {
   if (err.isOperational && err.cause) {


### PR DESCRIPTION
Avoid crashes if GRP is not defined