### PR TITLE
Support React Native 0.47

### DIFF
--- a/android/src/main/java/com/rngrp/RNGRPPackage.java
+++ b/android/src/main/java/com/rngrp/RNGRPPackage.java
@@ -17,7 +17,6 @@ public class RNGRPPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
React Native 0.47 has Breaking Changes of Android.
`createJSModules` is removed.

> https://github.com/facebook/react-native/releases/tag/v0.47.2

Removed `@Override`. this change is backward compatible. same as Sentry way.

> https://github.com/getsentry/react-native-sentry/pull/172