### PR TITLE
Update for API 26+ compability.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,19 +4,25 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.+'
     }
 }
 
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext;
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.3';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 26;
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fixing AAPT crashing due to missing properties for API 26+ because of compile sdk was 25 or less.
Before this some style resources missed due to old target, compile sdk versions and old build tools version. My fix let this problem be fully disappeared. Everything is fully tested and reliable. So I recommend to merge this ASAP. Thanks) 